### PR TITLE
DOCS-4139 notes

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -10,6 +10,8 @@ to write directly to object store, use its REST API, and write and read using
 the Object Store connector. See the xref:osv2-faq.adoc[FAQ] for
 Object Store information.
 
+NOTE: Mule 4 only supports Object Store v2.
+
 image::osv2-architecture.png[width=300]
 
 Object Store v2 provides:

--- a/modules/ROOT/pages/osv2-faq.adoc
+++ b/modules/ROOT/pages/osv2-faq.adoc
@@ -17,7 +17,13 @@ Also London (eu-west-2) can be accessed from the US cloud, but not the EU cloud.
 
 Mule 3.8.5 and above, and all 4.x versions. 
 
-NOTE: Only Mule Runtimes deployed to CloudHub can use Object Store v2.
+[IMPORTANT] 
+====
+
+* Mule 4 only supports Object Store v2.
+* Only Mule Runtimes deployed to CloudHub can use Object Store v2.
+
+====
 
 == Is Object Store v2 persistent in the same region as the worker?
 


### PR DESCRIPTION
https://www.mulesoft.org/jira/browse/DOCS-4139 -- Added notes that Mule 4 only supports the use of Object Store v2.