### PR TITLE
Update osv2-apis.adoc

### DIFF
--- a/modules/ROOT/pages/osv2-apis.adoc
+++ b/modules/ROOT/pages/osv2-apis.adoc
@@ -178,7 +178,7 @@ Depending on the deployment region, use one of the following domains for the val
 | `object-store-ap-southeast-2.anypoint.mulesoft.com` | Asia Pacific (Sydney)
 | `object-store-ap-northeast-1.anypoint.mulesoft.com` | Asia Pacific (Tokyo)
 | `object-store-ca-central-1.anypoint.mulesoft.com` | Canada (Central)
-| `object-store-eu-west-2.eu1.anypoint.mulesoft.com` | Europe (London)
+| `object-store-eu-west-2.anypoint.mulesoft.com` | Europe (London)
 | `object-store-sa-east-1.anypoint.mulesoft.com` | South America (São Paulo)
 | `object-store-us-gov-west-1.gov.anypoint.mulesoft.com` | US Gov West
 .2+|`prod-eu` | `object-store-eu-central-1.eu1.anypoint.mulesoft.com` | Europe (Frankfurt)


### PR DESCRIPTION
The Base URL to London Region for US control plane is supposed to be "object-store-eu-west-2.anypoint.mulesoft.com" based on the testing done on 31st Aug, 2021.