### PR TITLE
Added a scenario when OSv2 is re-enabled

### DIFF
--- a/modules/ROOT/pages/osv2-faq.adoc
+++ b/modules/ROOT/pages/osv2-faq.adoc
@@ -186,7 +186,7 @@ same data center as the Runtime Manager app.
 
 == What happens when you reenable the *Use Object Store v2* option after disabling it?
 
-By default, the *Use Object Store v2* option is enabled when deploying the CloudHub application. If you disable and then reenable this option in Runtime Manager, the original key-value pairs persist as long as the key-value pair TTL is not expired. 
+By default, the *Use Object Store v2* option is enabled during CloudHub application deployment. If you disable and then reenable this option in Runtime Manager, the original key-value pairs persist as long as the key-value pair TTL is not expired. 
 
 == See Also
 

--- a/modules/ROOT/pages/osv2-faq.adoc
+++ b/modules/ROOT/pages/osv2-faq.adoc
@@ -184,6 +184,10 @@ Object Store v2 uses TLS for secure transport. Data at rest is stored using FIPS
 Object Store v2 performs I/O for each read and write. With Object Store v2, the API call is localized to the
 same data center as the Runtime Manager app.
 
+== What happens when OSv2 option is changed from disabled to enabled status?
+
+By default, OSv2 is enabled when deploying the CloudHub application. If the OSv2 option is disabled then re-enabled from Runtime Manager GUI, the original key/value pairs stay if the key/value pair TTL is not expired. 
+
 == See Also
 
 * https://anypoint.mulesoft.com/exchange/portals/anypoint-platform/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/object-store-v2/[Anypoint Exchange Object Store v2 API]

--- a/modules/ROOT/pages/osv2-faq.adoc
+++ b/modules/ROOT/pages/osv2-faq.adoc
@@ -184,7 +184,7 @@ Object Store v2 uses TLS for secure transport. Data at rest is stored using FIPS
 Object Store v2 performs I/O for each read and write. With Object Store v2, the API call is localized to the
 same data center as the Runtime Manager app.
 
-== What happens when OSv2 option is changed from disabled to enabled status?
+== What happens when you reenable the *Use Object Store v2* option after disabling it?
 
 By default, the *Use Object Store v2* option is enabled when deploying the CloudHub application. If you disable and then reenable this option in Runtime Manager, the original key-value pairs persist as long as the key-value pair TTL is not expired. 
 

--- a/modules/ROOT/pages/osv2-faq.adoc
+++ b/modules/ROOT/pages/osv2-faq.adoc
@@ -186,7 +186,7 @@ same data center as the Runtime Manager app.
 
 == What happens when OSv2 option is changed from disabled to enabled status?
 
-By default, OSv2 is enabled when deploying the CloudHub application. If the OSv2 option is disabled then re-enabled from Runtime Manager GUI, the original key/value pairs stay if the key/value pair TTL is not expired. 
+By default, the *Use Object Store v2* option is enabled when deploying the CloudHub application. If you disable and then reenable this option in Runtime Manager, the original key-value pairs persist as long as the key-value pair TTL is not expired. 
 
 == See Also
 


### PR DESCRIPTION
Added the expected behavior of key/value pair when the OSv2 option is changed from "Disabled' to "Enabled".
Be note that I have confirmed with @Shashi Chinthakindi from the engineering team and advised that this is expected behavior and should be documented.

The testing case is as below.
1. Deploy the app to the CloudHub
2. Send a request GET request to the app to create a key/pair
3. Disable OSv2 option and app gets restarted
4. The OSv2 data is not visible from GUI.
5. Enabled the OSv2 option, the key/value pair stays