### PR TITLE
W-23748914: Add United Kingdom Cloud to Object Store v2 docs

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -139,7 +139,7 @@ To avoid these issues, use a distributed key-value store as a lock to synchroniz
 
 [%header,cols="2a,1a,1a"]
 |===
-|Object Store Feature | US Cloud and EU Cloud | Canada Cloud, Japan Cloud, India Cloud, Australia Cloud
+|Object Store Feature | US Cloud and EU Cloud | Canada Cloud, Japan Cloud, India Cloud, Australia Cloud, United Kingdom Cloud
 
 |{empty}
 
@@ -173,12 +173,12 @@ To avoid these issues, use a distributed key-value store as a lock to synchroniz
 [[osv2-on-hyperforce]]
 === Limitations by Control Plane
 
-All Object Store v2 features are supported on https://ca1.platform.mulesoft.com[Canada Cloud], https://jp1.platform.mulesoft.com[Japan Cloud], https://in1.platform.mulesoft.com[India Cloud], and https://au1.platform.mulesoft.com[Australia Cloud] with the following exceptions:
+All Object Store v2 features are supported on https://ca1.platform.mulesoft.com[Canada Cloud], https://jp1.platform.mulesoft.com[Japan Cloud], https://in1.platform.mulesoft.com[India Cloud], https://au1.platform.mulesoft.com[Australia Cloud], and https://gb1.platform.mulesoft.com[United Kingdom Cloud] with the following exceptions:
 
 [%header,cols="2a,2a"]
 |===
 | Limitation
-| Canada Cloud, Japan Cloud, India Cloud, Australia Cloud
+| Canada Cloud, Japan Cloud, India Cloud, Australia Cloud, United Kingdom Cloud
 
 | *xref:cloudhub::deploying-to-cloudhub.adoc[CloudHub 1.0 Deployments]*
 | Not supported. Deploy apps to xref:cloudhub-2::ch2-shared-space-about.adoc[CloudHub 2.0 shared spaces] or xref:runtime-fabric::index.adoc[Anypoint Runtime Fabric].

--- a/modules/ROOT/pages/osv2-faq.adoc
+++ b/modules/ROOT/pages/osv2-faq.adoc
@@ -40,6 +40,9 @@ endif::[]
 | https://au1.platform.mulesoft.com[Australia Cloud]
 | Asia Pacific | Australia (Sydney) | `ap-southeast-2` <<os-hyperforce,^***^>>
 
+| https://gb1.platform.mulesoft.com[United Kingdom Cloud]
+| Europe | United Kingdom (London) | `eu-west-2` <<os-hyperforce,^***^>>
+
 | MuleSoft Government Cloud
 | US Government | US GovCloud (West) | `us-gov-west-1`
 |===


### PR DESCRIPTION
## Summary

Replicates the Australia Cloud changes from PR #149 for United Kingdom Cloud (`gb1.platform.mulesoft.com`).

- **`index.adoc`**: Updated the feature table column header, Limitations intro sentence, and Limitations table column header to include United Kingdom Cloud.
- **`osv2-faq.adoc`**: Added United Kingdom Cloud row (`eu-west-2`, Europe, United Kingdom (London)) to the Object Store v2 regions table.

Made with [Cursor](https://cursor.com)